### PR TITLE
Format agent answers with sources

### DIFF
--- a/graph/workflow.py
+++ b/graph/workflow.py
@@ -288,9 +288,18 @@ Context:
                     "input": state["prompt"],
                     "chat_history": messages[1:-1]  # Exclude system message
                 })
-                
-                # Update state with answer
-                state["answer"] = response["output"]
+
+                # Format answer with project identification and sources
+                rag_chain = self.rag_chain_factory(state["project_name"])
+                formatted = rag_chain.format_response_with_sources(
+                    response["output"],
+                    context_docs,
+                    state["project_id"],
+                    state["project_name"],
+                )
+
+                # Update state with formatted answer
+                state["answer"] = formatted
                 state["messages"].append({"role": "assistant", "content": state["answer"]})
                 
             except Exception as e:


### PR DESCRIPTION
## Summary
- ensure formatted answer with sources is used after tool-based generation

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b9cbba44c832da01432c9d6c2c44a